### PR TITLE
Touch all bandit arms once

### DIFF
--- a/lib/tests/epsilon_greedy.rb
+++ b/lib/tests/epsilon_greedy.rb
@@ -9,6 +9,10 @@ class Tests::EpsilonGreedy < Tests::Base
   def initialize(*args)
     super
     @name = 'Epsilon Greedy'
+    # Explicitly initialize
+    variants.each do |name|
+      variant_data[name].increment_count
+    end
   end
 
 
@@ -23,7 +27,7 @@ class Tests::EpsilonGreedy < Tests::Base
   end
 
   def determine_variant_for_user
-    if rand < RANDOM_RATE or variant_data.empty?
+    if rand < RANDOM_RATE
       random_variant
     else
       most_lucrative_variant


### PR DESCRIPTION
Using implicit initialization, variant names were only added to variant_data
when a random_variant was selected.

Selecting the most lucrative variant, when all were not present, lead to
buggy behaviour.  One bandit arm would be chosen, over and over, not
even considering the others, until a roll of the RNG made them available
for consideration too.

With small sample sizes, this would lead to measurable defects.
